### PR TITLE
Fix capitalization of readme in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
   { name="ninjakakes" }
 ]
 description = "randomizer for Super Junkoid"
-readme = "readme.md"
+readme = "README.md"
 requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
This was probably developed on a case insensitive filesystem where it worked. Unfortunately (or fortunately...), this isn't how the rest of the world works which means this was not installable if you filesystem does care about casing.